### PR TITLE
Refactor + add ClickHouse support, bump to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,6 +31,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,6 +111,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-native-tls"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d57d4cec3c647232e1094dc013546c0b33ce785d8aeb251e1f20dfaf8a9a13fe"
+dependencies = [
+ "futures-util",
+ "native-tls",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -113,6 +134,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "asynchronous-codec"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4057f2c32adbb2fc158e22fb38433c8e9bbf76b75a4732c7c0cbaf695fb65568"
+dependencies = [
+ "bytes",
+ "futures-sink",
+ "futures-util",
+ "memchr",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +154,12 @@ checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -165,15 +205,6 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitflags"
@@ -268,12 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
-
-[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -340,6 +365,12 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "connection-string"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "510ca239cf13b7f8d16a2b48f263de7b4f8c566f0af58d901031473c76afb1e3"
 
 [[package]]
 name = "const-oid"
@@ -414,15 +445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -451,16 +473,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "ctrlc"
-version = "3.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f93780a459b7d656ef7f071fe699c4d3d2cb201c4b24d085b6ddc505276e73"
-dependencies = [
- "nix",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -605,12 +617,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -659,16 +700,6 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
-name = "flate2"
-version = "1.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "flume"
@@ -972,10 +1003,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "iana-time-zone"
@@ -1166,6 +1279,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,15 +1315,21 @@ name = "kaiwadb-agent"
 version = "0.2.1"
 dependencies = [
  "clap",
- "ctrlc",
  "futures-util",
  "mongodb",
+ "percent-encoding",
+ "reqwest",
  "serde",
  "serde_json",
  "sqlx",
- "syntect",
+ "thiserror 2.0.12",
+ "tiberius",
  "tokio",
  "tokio-tungstenite",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -1230,7 +1359,6 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
- "cc",
  "pkg-config",
  "vcpkg",
 ]
@@ -1324,6 +1452,15 @@ dependencies = [
  "macro_magic_core",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -1441,15 +1578,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.30.1"
+name = "nu-ansi-term"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "bitflags 2.9.1",
- "cfg-if",
- "cfg_aliases",
- "libc",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1525,28 +1659,6 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
-
-[[package]]
-name = "onig"
-version = "6.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
-dependencies = [
- "bitflags 2.9.1",
- "libc",
- "once_cell",
- "onig_sys",
-]
-
-[[package]]
-name = "onig_sys"
-version = "69.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
-dependencies = [
- "cc",
- "pkg-config",
-]
 
 [[package]]
 name = "openssl"
@@ -1685,19 +1797,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "plist"
-version = "1.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
-dependencies = [
- "base64 0.22.1",
- "indexmap 2.10.0",
- "quick-xml",
- "serde",
- "time",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,21 +1821,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.38.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -1849,10 +1945,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "resolv-conf"
@@ -2008,15 +2151,6 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -2202,6 +2336,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2523,6 +2666,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2531,28 +2683,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
-]
-
-[[package]]
-name = "syntect"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874dcfa363995604333cf947ae9f751ca3af4522c60886774c4963943b4746b1"
-dependencies = [
- "bincode",
- "bitflags 1.3.2",
- "flate2",
- "fnv",
- "once_cell",
- "onig",
- "plist",
- "regex-syntax",
- "serde",
- "serde_derive",
- "serde_json",
- "thiserror 1.0.69",
- "walkdir",
- "yaml-rust",
 ]
 
 [[package]]
@@ -2618,6 +2748,39 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tiberius"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1446cb4198848d1562301a3340424b4f425ef79f35ef9ee034769a9dd92c10d"
+dependencies = [
+ "async-native-tls",
+ "async-trait",
+ "asynchronous-codec",
+ "byteorder",
+ "bytes",
+ "connection-string",
+ "encoding_rs",
+ "enumflags2",
+ "futures-util",
+ "num-traits",
+ "once_cell",
+ "pin-project-lite",
+ "pretty-hex",
+ "thiserror 1.0.69",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -2776,6 +2939,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2805,7 +3013,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
 ]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
@@ -2917,6 +3174,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2929,13 +3192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
+name = "want"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "same-file",
- "winapi-util",
+ "try-lock",
 ]
 
 [[package]]
@@ -2986,6 +3248,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.50"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3015,6 +3290,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3056,15 +3341,6 @@ name = "widestring"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
-dependencies = [
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "windows-core"
@@ -3378,15 +3654,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1312,7 +1312,7 @@ dependencies = [
 
 [[package]]
 name = "kaiwadb-agent"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaiwadb-agent"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2024"
 repository = "https://github.com/kaiwadb/agent"
 license-file = "LICENSE"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ publish = false
 
 [dependencies]
 clap = { version = "4.5.41", features = ["derive", "env"] }
-ctrlc = "3.4.7"
 futures-util = "0.3.31"
 mongodb = "3.2.4"
 serde = { version = "1.0.219", features = ["derive"] }
@@ -18,13 +17,19 @@ sqlx = { version = "0.8.6", features = [
     "runtime-tokio-rustls",
     "postgres",
     "mysql",
-    "sqlite",
     "chrono",
     "uuid",
 ] }
-syntect = "5.2.0"
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
+tiberius = { version = "0.12", default-features = false, features = ["tds73", "native-tls"] }
+thiserror = "2"
 tokio = { version = "1.46.1", features = ["full"] }
 tokio-tungstenite = { version = "0.27.0", features = ["native-tls"] }
+tokio-util = { version = "0.7", features = ["compat"] }
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["json", "env-filter"] }
+percent-encoding = "2"
+url = "2"
 
 [profile.dist]
 inherits = "release"

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,96 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1776548001,
+        "narHash": "sha256-ZSK0NL4a1BwVbbTBoSnWgbJy9HeZFXLYQizjb2DPF24=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b12141ef619e0a9c1c84dc8c684040326f27cdcc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1776827647,
+        "narHash": "sha256-sYixYhp5V8jCajO8TRorE4fzs7IkL4MZdfLTKgkPQBk=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "40e6ccc06e1245a4837cbbd6bdda64e21cc67379",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = { nixpkgs, flake-utils, rust-overlay, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+        rust = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" "clippy" ];
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [ rust pkg-config ];
+          buildInputs = with pkgs; [ openssl ];
+          env = {
+            RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";
+            LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          };
+        };
+      });
+}

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -1,6 +1,7 @@
-use super::query::Query;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+
+use crate::query::Query;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ServerCommand {

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,107 @@
+use futures_util::{SinkExt, StreamExt};
+use std::time::Duration;
+use tokio::time::interval;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{Message, client::IntoClientRequest, http::Request},
+};
+use tracing::{debug, error, info};
+
+use crate::communication::{AgentResult, AgentResultMsg, PayloadFromAgent, ServerCommand, ServerCommandMsg};
+use crate::error::AgentError;
+
+const HEARTBEAT_PERIOD: Duration = Duration::from_secs(15);
+const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+
+pub async fn run(uri: String, token: String) -> Result<(), AgentError> {
+    let mut request = uri.into_client_request().map_err(|e| {
+        AgentError::Connection(format!("invalid WebSocket URI: {e}"))
+    })?;
+    request
+        .headers_mut()
+        .insert("Authorization", format!("Bearer {}", token).parse()?);
+
+    loop {
+        match connect_and_handle(request.clone()).await {
+            Ok(()) => {
+                info!("connection ended normally");
+                break;
+            }
+            Err(e) => {
+                error!(error = %e, "connection error");
+                info!(delay_secs = RECONNECT_DELAY.as_secs(), "reconnecting");
+                tokio::time::sleep(RECONNECT_DELAY).await;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn connect_and_handle(request: Request<()>) -> Result<(), AgentError> {
+    let (ws_stream, _) = connect_async(request).await?;
+    info!("connected");
+
+    let (mut write, mut read) = ws_stream.split();
+    let mut heartbeat_interval = interval(HEARTBEAT_PERIOD);
+
+    loop {
+        tokio::select! {
+            msg = read.next() => {
+                match msg {
+                    Some(Ok(Message::Text(text))) => {
+                        if let Err(e) = handle_server_message(text.to_string(), &mut write).await {
+                            error!(error = %e, "error handling message");
+                        }
+                    }
+                    Some(Ok(Message::Ping(payload))) => {
+                        write.send(Message::Pong(payload)).await?;
+                    }
+                    Some(Ok(Message::Pong(_))) => continue,
+                    Some(Ok(Message::Close(frame))) => {
+                        info!(?frame, "connection closed by server");
+                        break;
+                    }
+                    Some(Ok(Message::Binary(_) | Message::Frame(_))) => continue,
+                    Some(Err(e)) => return Err(e.into()),
+                    None => return Err(AgentError::Connection("connection closed unexpectedly".into())),
+                }
+            }
+            _ = heartbeat_interval.tick() => {
+                write.send(Message::Ping("heartbeat".into())).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_server_message(
+    text: String,
+    write: &mut futures_util::stream::SplitSink<
+        tokio_tungstenite::WebSocketStream<
+            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+        >,
+        Message,
+    >,
+) -> Result<(), AgentError> {
+    let msg: ServerCommandMsg = serde_json::from_str(&text)?;
+
+    match msg.payload {
+        ServerCommand::Query(query) => {
+            let data = query.execute().await?;
+            debug!("query completed, sending response");
+
+            let response = PayloadFromAgent::Result(AgentResultMsg {
+                channel: msg.channel,
+                payload: AgentResult::QueryResult(data),
+            });
+            let response_txt = serde_json::to_string(&response)?;
+            write
+                .send(Message::Text(response_txt.as_str().into()))
+                .await?;
+        }
+    }
+
+    Ok(())
+}

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -1,0 +1,246 @@
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::fmt;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum D2Direction {
+    Up,
+    #[default]
+    Down,
+    Left,
+    Right,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum Engine {
+    Postgres { version: SemVer },
+    Clickhouse { version: SemVer },
+    BigQuery,
+    MsSql { version: SemVer },
+    MySQL { version: SemVer },
+    Mongo { version: SemVer },
+    D2 {
+        #[serde(default = "default_d2_version")]
+        version: SemVer,
+        #[serde(default)]
+        direction: D2Direction,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        background_fill: Option<String>,
+    },
+}
+
+fn default_d2_version() -> SemVer {
+    SemVer::new(0, 7, 1)
+}
+
+#[derive(Debug, Clone)]
+pub struct SemVer {
+    major: u32,
+    minor: u32,
+    patch: u32,
+}
+
+impl SemVer {
+    pub fn new(major: u32, minor: u32, patch: u32) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+}
+
+impl fmt::Display for SemVer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl Serialize for SemVer {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for SemVer {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(SemVerVisitor)
+    }
+}
+
+struct SemVerVisitor;
+
+impl<'de> Visitor<'de> for SemVerVisitor {
+    type Value = SemVer;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a semantic version string like '1.2.3'")
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        let parts: Vec<&str> = value.split('.').collect();
+
+        if parts.len() != 3 {
+            return Err(E::custom(format!(
+                "expected version format 'major.minor.patch', got '{}'",
+                value
+            )));
+        }
+
+        let major = parts[0]
+            .parse::<u32>()
+            .map_err(|_| E::custom(format!("invalid major version: '{}'", parts[0])))?;
+
+        let minor = parts[1]
+            .parse::<u32>()
+            .map_err(|_| E::custom(format!("invalid minor version: '{}'", parts[1])))?;
+
+        let patch = parts[2]
+            .parse::<u32>()
+            .map_err(|_| E::custom(format!("invalid patch version: '{}'", parts[2])))?;
+
+        Ok(SemVer {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn semver_serialize() {
+        let v = SemVer::new(1, 2, 3);
+        assert_eq!(serde_json::to_string(&v).unwrap(), "\"1.2.3\"");
+    }
+
+    #[test]
+    fn semver_deserialize() {
+        let v: SemVer = serde_json::from_str("\"16.0.0\"").unwrap();
+        assert_eq!(v.major, 16);
+        assert_eq!(v.minor, 0);
+        assert_eq!(v.patch, 0);
+    }
+
+    #[test]
+    fn semver_deserialize_invalid() {
+        assert!(serde_json::from_str::<SemVer>("\"1.2\"").is_err());
+    }
+
+    #[test]
+    fn engine_postgres() {
+        let json = serde_json::json!({"type": "postgres", "version": "16.0.0"});
+        let e: Engine = serde_json::from_value(json).unwrap();
+        assert!(matches!(e, Engine::Postgres { .. }));
+    }
+
+    #[test]
+    fn engine_mongo() {
+        let json = serde_json::json!({"type": "mongo", "version": "7.0.0"});
+        let e: Engine = serde_json::from_value(json).unwrap();
+        assert!(matches!(e, Engine::Mongo { .. }));
+    }
+
+    #[test]
+    fn engine_mysql() {
+        let json = serde_json::json!({"type": "mysql", "version": "8.0.0"});
+        let e: Engine = serde_json::from_value(json).unwrap();
+        assert!(matches!(e, Engine::MySQL { .. }));
+    }
+
+    #[test]
+    fn engine_clickhouse() {
+        let json = serde_json::json!({"type": "clickhouse", "version": "24.0.0"});
+        let e: Engine = serde_json::from_value(json).unwrap();
+        assert!(matches!(e, Engine::Clickhouse { .. }));
+    }
+
+    #[test]
+    fn engine_bigquery() {
+        let json = serde_json::json!({"type": "bigquery"});
+        let e: Engine = serde_json::from_value(json).unwrap();
+        assert!(matches!(e, Engine::BigQuery));
+    }
+
+    #[test]
+    fn engine_mssql() {
+        let json = serde_json::json!({"type": "mssql", "version": "16.0.0"});
+        let e: Engine = serde_json::from_value(json).unwrap();
+        assert!(matches!(e, Engine::MsSql { .. }));
+    }
+
+    #[test]
+    fn engine_d2_defaults() {
+        let json = serde_json::json!({"type": "d2"});
+        let e: Engine = serde_json::from_value(json).unwrap();
+        match e {
+            Engine::D2 {
+                version,
+                direction,
+                background_fill,
+            } => {
+                assert_eq!(version.major, 0);
+                assert_eq!(version.minor, 7);
+                assert_eq!(version.patch, 1);
+                assert_eq!(direction, D2Direction::Down);
+                assert_eq!(background_fill, None);
+            }
+            _ => panic!("expected D2"),
+        }
+    }
+
+    #[test]
+    fn engine_d2_with_options() {
+        let json = serde_json::json!({
+            "type": "d2",
+            "version": "0.7.1",
+            "direction": "right",
+            "background_fill": "#f5f5f5"
+        });
+        let e: Engine = serde_json::from_value(json).unwrap();
+        match e {
+            Engine::D2 {
+                direction,
+                background_fill,
+                ..
+            } => {
+                assert_eq!(direction, D2Direction::Right);
+                assert_eq!(background_fill, Some("#f5f5f5".to_string()));
+            }
+            _ => panic!("expected D2"),
+        }
+    }
+
+    #[test]
+    fn roundtrip_all_engines() {
+        let inputs = vec![
+            serde_json::json!({"type": "postgres", "version": "16.0.0"}),
+            serde_json::json!({"type": "clickhouse", "version": "24.0.0"}),
+            serde_json::json!({"type": "bigquery"}),
+            serde_json::json!({"type": "mssql", "version": "16.0.0"}),
+            serde_json::json!({"type": "mysql", "version": "8.0.0"}),
+            serde_json::json!({"type": "mongo", "version": "7.0.0"}),
+            serde_json::json!({"type": "d2", "version": "0.6.0", "direction": "down"}),
+        ];
+
+        for input in inputs {
+            let engine: Engine = serde_json::from_value(input.clone()).unwrap();
+            let serialized = serde_json::to_value(&engine).unwrap();
+            assert_eq!(input, serialized, "roundtrip failed for {input}");
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,29 @@
+#[derive(Debug, thiserror::Error)]
+pub enum AgentError {
+    #[error("WebSocket error: {0}")]
+    WebSocket(Box<tokio_tungstenite::tungstenite::Error>),
+
+    #[error("Serialization error: {0}")]
+    Serialization(#[from] serde_json::Error),
+
+    #[error("MongoDB error: {0}")]
+    Mongo(#[from] mongodb::error::Error),
+
+    #[error("SQL error: {0}")]
+    Sql(#[from] sqlx::Error),
+
+    #[error("Unsupported engine: {0}")]
+    UnsupportedEngine(String),
+
+    #[error("Connection error: {0}")]
+    Connection(String),
+
+    #[error("Invalid header: {0}")]
+    InvalidHeader(#[from] tokio_tungstenite::tungstenite::http::header::InvalidHeaderValue),
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for AgentError {
+    fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
+        AgentError::WebSocket(Box::new(err))
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,12 @@
 mod communication;
+mod connection;
+mod engine;
+mod error;
 mod query;
 
 use clap::Parser;
-use communication::{ServerCommand, ServerCommandMsg};
-use futures_util::{SinkExt, StreamExt};
-use std::time::Duration;
-use tokio::time::interval;
-use tokio_tungstenite::{
-    connect_async,
-    tungstenite::{Message, client::IntoClientRequest, http::Request},
-};
-
-use crate::{
-    communication::{AgentResult, AgentResultMsg, PayloadFromAgent},
-    query::QueryOptions,
-};
-
-const HEARTBEAT_PERIOD: Duration = Duration::from_secs(15);
-const RECONNECT_DELAY: Duration = Duration::from_secs(5);
+use tracing::info;
+use tracing_subscriber::{EnvFilter, fmt, prelude::*};
 
 #[derive(Parser)]
 #[command(name = "kaiwadb-agent")]
@@ -31,132 +20,21 @@ struct Args {
     /// Authentication token
     #[arg(short, long, env = "KAIWADB_AGENT_TOKEN")]
     token: String,
-
-    /// Enable rich logging with colors, syntax highlighting, and loading indicators
-    #[arg(short, long, default_value = "false")]
-    rich_logging: bool,
-
-    /// Maximum length of query results printed to stdout
-    #[arg(short = 'l', long, default_value = "2000")]
-    max_stdout_result_length: usize,
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+async fn main() -> Result<(), error::AgentError> {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let registry = tracing_subscriber::registry().with(filter);
+
+    if std::io::IsTerminal::is_terminal(&std::io::stdout()) {
+        registry.with(fmt::layer().pretty()).init();
+    } else {
+        registry.with(fmt::layer().json()).init();
+    }
+
     let args = Args::parse();
 
-    let query_options = QueryOptions {
-        rich_logging: args.rich_logging,
-        max_stdout_result_length: args.max_stdout_result_length,
-    };
-
-    println!("🚀 Starting KaiwaDB Agent");
-    println!("📡 Connecting to: {}", args.uri);
-
-    let mut request = args.uri.into_client_request()?;
-    request
-        .headers_mut()
-        .insert("Authorization", format!("Bearer {}", args.token).parse()?);
-
-    loop {
-        match connect_and_handle(request.clone(), query_options.clone()).await {
-            Ok(_) => {
-                println!("Connection ended normally");
-                break;
-            }
-            Err(e) => {
-                println!("❌ Connection error: {}", e);
-
-                println!("⏳ Reconnecting in {}s...", RECONNECT_DELAY.as_secs());
-                tokio::time::sleep(RECONNECT_DELAY).await;
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn connect_and_handle(
-    request: Request<()>,
-    query_options: QueryOptions,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let (ws_stream, _) = connect_async(request).await?;
-
-    println!("✅ Connected!");
-
-    let (mut write, mut read) = ws_stream.split();
-    let mut heartbeat_interval = interval(HEARTBEAT_PERIOD);
-
-    loop {
-        tokio::select! {
-            msg = read.next() => {
-                match msg {
-                    Some(Ok(Message::Text(text))) => {
-                        if let Err(e) = handle_server_message(text.to_string(), &mut write, query_options.clone()).await {
-                            println!("Error handling message: {}", e);
-                        }
-                    }
-                    Some(Ok(Message::Ping(payload))) => {
-                        write.send(Message::Pong(payload)).await?;
-                    }
-                    Some(Ok(Message::Pong(_))) => {
-                        continue
-                    }
-                    Some(Ok(Message::Close(frame))) => {
-                        println!("Connection closed by server: {:?}", frame);
-                        break;
-                    }
-                    Some(Ok(Message::Binary(_))) => {
-                        continue
-                    }
-                    Some(Ok(Message::Frame(_))) => {
-                        continue
-                    }
-                    Some(Err(e)) => {
-                        return Err(format!("WebSocket error: {}", e).into());
-                    }
-                    None => {
-                        return Err("Connection closed unexpectedly".into());
-                    }
-                }
-            }
-            _ = heartbeat_interval.tick() => {
-                if let Err(e) = write.send(Message::Ping("heartbeat".into())).await {
-                    return Err(format!("Failed to send heartbeat: {}", e).into());
-                }
-            }
-        }
-    }
-    Ok(())
-}
-
-async fn handle_server_message(
-    text: String,
-    write: &mut futures_util::stream::SplitSink<
-        tokio_tungstenite::WebSocketStream<
-            tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
-        >,
-        Message,
-    >,
-    query_options: QueryOptions,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let msg: ServerCommandMsg = serde_json::from_str(&text)
-        .map_err(|e| format!("Failed to parse server message: {}", e))?;
-
-    match msg.payload {
-        ServerCommand::Query(query) => {
-            let data = query.execute(query_options).await?;
-            println!("Query completed successfully");
-            let response = PayloadFromAgent::Result(AgentResultMsg {
-                channel: msg.channel,
-                payload: AgentResult::QueryResult(data),
-            });
-            let response_txt = serde_json::to_string(&response)?;
-            write
-                .send(Message::Text(response_txt.as_str().into()))
-                .await?;
-            println!("Sent response");
-        }
-    }
-
-    Ok(())
+    info!(uri = %args.uri, "starting kaiwadb agent");
+    connection::run(args.uri, args.token).await
 }

--- a/src/query/clickhouse.rs
+++ b/src/query/clickhouse.rs
@@ -1,0 +1,107 @@
+use std::sync::LazyLock;
+
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::Value;
+use tracing::info;
+use percent_encoding::percent_decode_str;
+use url::Url;
+
+use crate::error::AgentError;
+
+static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
+    Client::builder()
+        .build()
+        .expect("failed to build HTTP client")
+});
+
+pub async fn execute(uri: &str, query: &str) -> Result<Value, AgentError> {
+    let parsed = parse_uri(uri)?;
+
+    info!(host = %parsed.url, "executing clickhouse query");
+
+    let mut request = HTTP_CLIENT.post(&parsed.url);
+
+    if let Some(db) = &parsed.database {
+        request = request.query(&[("database", db.as_str())]);
+    }
+
+    if let Some(user) = &parsed.username {
+        request = request.basic_auth(user, parsed.password.as_deref());
+    }
+
+    let body = format!("{query} FORMAT JSON");
+    let response = request
+        .body(body)
+        .send()
+        .await
+        .map_err(|e| AgentError::Connection(format!("clickhouse HTTP error: {e}")))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response.text().await.unwrap_or_default();
+        return Err(AgentError::Connection(format!(
+            "clickhouse returned {status}: {text}"
+        )));
+    }
+
+    let result: ClickhouseResponse = response
+        .json()
+        .await
+        .map_err(|e| AgentError::Connection(format!("clickhouse response parse error: {e}")))?;
+
+    Ok(Value::Array(result.data))
+}
+
+#[derive(Deserialize)]
+struct ClickhouseResponse {
+    data: Vec<Value>,
+}
+
+struct ParsedUri {
+    url: String,
+    database: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+}
+
+fn parse_uri(uri: &str) -> Result<ParsedUri, AgentError> {
+    // Normalize clickhouse:// scheme to http:// for parsing
+    let normalized = if uri.starts_with("clickhouse://") {
+        uri.replacen("clickhouse://", "http://", 1)
+    } else {
+        uri.to_string()
+    };
+
+    let parsed = Url::parse(&normalized)
+        .map_err(|e| AgentError::Connection(format!("invalid clickhouse URI: {e}")))?;
+
+    let host = parsed.host_str().unwrap_or("localhost");
+    let port = parsed.port().unwrap_or(8123);
+    let database = parsed
+        .path()
+        .strip_prefix('/')
+        .filter(|s| !s.is_empty())
+        .map(String::from);
+    let username = if parsed.username().is_empty() {
+        None
+    } else {
+        Some(
+            percent_decode_str(parsed.username())
+                .decode_utf8_lossy()
+                .into_owned(),
+        )
+    };
+    let password = parsed.password().map(|p| {
+        percent_decode_str(p)
+            .decode_utf8_lossy()
+            .into_owned()
+    });
+
+    Ok(ParsedUri {
+        url: format!("http://{host}:{port}/"),
+        database,
+        username,
+        password,
+    })
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,65 +1,23 @@
+mod clickhouse;
 mod mongo;
+mod mssql;
+mod mysql;
 mod postgres;
+
 use mongodb::bson::Document;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, from_value};
 use std::time::Instant;
-use syntect::{
-    easy::HighlightLines, highlighting::ThemeSet, parsing::SyntaxSet, util::LinesWithEndings,
-};
+use tracing::{debug, error, info};
+
+use crate::engine::Engine;
+use crate::error::AgentError;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Query {
     pub uri: String,
-    pub engine: DBEngine,
+    pub engine: Engine,
     pub data: Value,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-#[serde(tag = "type", rename_all = "lowercase")]
-pub enum DBEngine {
-    Mongo(MongoEngine),
-    Postgres(PostgreSQLEngine),
-    MySQL(MySQLEngine),
-    MSSQL(MSSQLEngine),
-    Oracle(OracleEngine),
-    SQLite(SQLiteEngine),
-    MariaDB(MariaDBEngine),
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct MongoEngine {
-    pub version: u16,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct PostgreSQLEngine {
-    pub version: u16,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct MySQLEngine {
-    pub version: u16,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct MSSQLEngine {
-    pub version: u16,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct OracleEngine {
-    pub version: u16,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct SQLiteEngine {
-    pub version: u16,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
-pub struct MariaDBEngine {
-    pub version: u16,
 }
 
 #[derive(Deserialize)]
@@ -68,67 +26,46 @@ struct MongoData {
     pipeline: Vec<Document>,
 }
 
-#[derive(Clone)]
-pub struct QueryOptions {
-    pub rich_logging: bool,
-    pub max_stdout_result_length: usize,
-}
-
 impl Query {
-    pub async fn execute(self, options: QueryOptions) -> Result<Value, Box<dyn std::error::Error>> {
-        self.execute_with_options(options).await
-    }
-
-    pub async fn execute_with_options(
-        self,
-        options: QueryOptions,
-    ) -> Result<Value, Box<dyn std::error::Error>> {
-        if options.rich_logging {
-            self.execute_with_rich_logging(options).await
-        } else {
-            self.execute_with_simple_logging(options).await
-        }
-    }
-
-    async fn execute_with_simple_logging(
-        self,
-        options: QueryOptions,
-    ) -> Result<Value, Box<dyn std::error::Error>> {
+    pub async fn execute(self) -> Result<Value, AgentError> {
         let start = Instant::now();
 
-        match &self.engine {
-            DBEngine::Mongo(_) => {
-                let MongoData {
-                    collection,
-                    pipeline,
-                } = from_value(self.data.clone())?;
-                println!("Executing MongoDB query on collection: {}", collection);
-                println!("Pipeline: {}", serde_json::to_string_pretty(&pipeline)?);
-            }
-            DBEngine::Postgres(_) => {
-                let query: String = from_value(self.data.clone())?;
-                println!("Executing PostgreSQL query:");
-                println!("{}", query);
-            }
-            engine => {
-                println!("Executing query on {:?}", engine);
-            }
-        }
-
         let result = match self.engine {
-            DBEngine::Mongo(_) => {
+            Engine::Mongo { .. } => {
                 let MongoData {
                     collection,
                     pipeline,
                 } = from_value(self.data)?;
+                info!(collection = %collection, "executing mongodb query");
+                debug!(pipeline = ?pipeline);
                 mongo::execute(&self.uri, collection, pipeline).await
             }
-            DBEngine::Postgres(_) => {
+            Engine::Postgres { .. } => {
                 let query: String = from_value(self.data)?;
+                info!("executing postgresql query");
+                debug!(query = %query);
                 postgres::execute(&self.uri, &query).await
             }
-            engine => {
-                return Err(format!("Agent cannot yet send queries to {:?}", engine).into());
+            Engine::MySQL { .. } => {
+                let query: String = from_value(self.data)?;
+                info!("executing mysql query");
+                debug!(query = %query);
+                mysql::execute(&self.uri, &query).await
+            }
+            Engine::MsSql { .. } => {
+                let query: String = from_value(self.data)?;
+                info!("executing mssql query");
+                debug!(query = %query);
+                mssql::execute(&self.uri, &query).await
+            }
+            Engine::Clickhouse { .. } => {
+                let query: String = from_value(self.data)?;
+                info!("executing clickhouse query");
+                debug!(query = %query);
+                clickhouse::execute(&self.uri, &query).await
+            }
+            ref engine => {
+                return Err(AgentError::UnsupportedEngine(format!("{engine:?}")));
             }
         };
 
@@ -136,133 +73,14 @@ impl Query {
 
         match &result {
             Ok(value) => {
-                let result_str = serde_json::to_string_pretty(value)?;
-                let truncated = if result_str.len() > options.max_stdout_result_length {
-                    format!(
-                        "{}... (truncated)",
-                        &result_str[..options.max_stdout_result_length]
-                    )
-                } else {
-                    result_str
-                };
-                println!("Query completed in {:?}", duration);
-                println!("Result: {}", truncated);
+                info!(duration_ms = duration.as_millis(), "query completed");
+                debug!(result = %serde_json::to_string_pretty(value).unwrap_or_default());
             }
             Err(e) => {
-                println!("Query failed in {:?}: {}", duration, e);
+                error!(duration_ms = duration.as_millis(), error = %e, "query failed");
             }
         }
 
         result
-    }
-
-    async fn execute_with_rich_logging(
-        self,
-        options: QueryOptions,
-    ) -> Result<Value, Box<dyn std::error::Error>> {
-        let start = Instant::now();
-
-        let ps = SyntaxSet::load_defaults_newlines();
-        let ts = ThemeSet::load_defaults();
-        let theme = &ts.themes["base16-ocean.dark"];
-
-        match &self.engine {
-            DBEngine::Mongo(_) => {
-                let MongoData {
-                    collection,
-                    pipeline,
-                } = from_value(self.data.clone())?;
-
-                println!("🔗 MongoDB Query");
-                println!("Collection: {}", collection);
-                println!("Pipeline:");
-                let formatted_pipeline = serde_json::to_string_pretty(&pipeline)?;
-                let highlighted = self.highlight_and_print(&formatted_pipeline, "JSON", &ps, theme);
-                println!("{}", highlighted);
-            }
-            DBEngine::Postgres(_) => {
-                let query: String = from_value(self.data.clone())?;
-                println!("🐘 PostgreSQL Query:");
-                let highlighted = self.highlight_and_print(&query, "SQL", &ps, theme);
-                println!("{}", highlighted);
-            }
-            engine => {
-                println!("📊 Executing query on {:?}", engine);
-            }
-        }
-
-        println!("⏳ Executing query...");
-
-        let result = match self.engine {
-            DBEngine::Mongo(_) => {
-                let MongoData {
-                    collection,
-                    pipeline,
-                } = from_value(self.data.clone())?;
-                mongo::execute(&self.uri, collection, pipeline).await
-            }
-            DBEngine::Postgres(_) => {
-                let query: String = from_value(self.data.clone())?;
-                postgres::execute(&self.uri, &query).await
-            }
-            engine => {
-                return Err(format!("Agent cannot yet send queries to {:?}", engine).into());
-            }
-        };
-
-        let duration = start.elapsed();
-
-        match &result {
-            Ok(value) => {
-                println!("✅ Query completed in {:?}", duration);
-                println!("📋 Result:");
-                let result_str = serde_json::to_string_pretty(value)?;
-                let truncated = if result_str.len() > options.max_stdout_result_length {
-                    format!(
-                        "{}... (truncated)",
-                        &result_str[..options.max_stdout_result_length]
-                    )
-                } else {
-                    result_str
-                };
-                let highlighted = self.highlight_and_print(&truncated, "JSON", &ps, theme);
-                println!("{}", highlighted);
-            }
-            Err(e) => {
-                println!("❌ Query failed in {:?}: {}", duration, e);
-            }
-        }
-
-        result
-    }
-
-    fn highlight_and_print(
-        &self,
-        text: &str,
-        syntax_name: &str,
-        ps: &SyntaxSet,
-        theme: &syntect::highlighting::Theme,
-    ) -> String {
-        let syntax = ps
-            .find_syntax_by_name(syntax_name)
-            .unwrap_or_else(|| ps.find_syntax_plain_text());
-
-        let mut highlighter = HighlightLines::new(syntax, theme);
-        let mut output = String::new();
-
-        for line in LinesWithEndings::from(text) {
-            let ranges = highlighter.highlight_line(line, ps).unwrap_or_default();
-            for (style, text) in ranges {
-                let color_code = format!(
-                    "\x1b[38;2;{};{};{}m",
-                    style.foreground.r, style.foreground.g, style.foreground.b
-                );
-                output.push_str(&color_code);
-                output.push_str(text);
-                output.push_str("\x1b[0m");
-            }
-        }
-
-        output
     }
 }

--- a/src/query/mongo.rs
+++ b/src/query/mongo.rs
@@ -1,22 +1,43 @@
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
 use mongodb::{Client, Collection, bson::Document};
 use serde_json::{Value, to_value};
+use tracing::info;
+
+use crate::error::AgentError;
+
+static CLIENTS: LazyLock<Mutex<HashMap<String, Client>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
 
 pub async fn execute(
     uri: &str,
     collection: String,
     pipeline: Vec<Document>,
-) -> Result<Value, Box<dyn std::error::Error>> {
-    println!(
-        "Connecting to MongoDB: {}",
-        uri.split('@').last().unwrap_or("unknown")
-    );
-    let client = Client::with_uri_str(&uri).await?;
+) -> Result<Value, AgentError> {
+    let client = {
+        let clients = CLIENTS.lock().unwrap();
+        clients.get(uri).cloned()
+    };
+
+    let client = match client {
+        Some(client) => client,
+        None => {
+            info!(
+                host = uri.split('@').next_back().unwrap_or("unknown"),
+                "creating new mongodb client"
+            );
+            let client = Client::with_uri_str(uri).await?;
+            CLIENTS.lock().unwrap().insert(uri.to_string(), client.clone());
+            client
+        }
+    };
+
     let db = client
         .default_database()
-        .ok_or("No default database specified in URI")?;
+        .ok_or(AgentError::Connection("no default database specified in URI".into()))?;
     let collection: Collection<Document> = db.collection(&collection);
 
-    println!("Executing query...");
     let mut cursor = collection.aggregate(pipeline).await?;
     let mut batch = Vec::new();
 

--- a/src/query/mssql.rs
+++ b/src/query/mssql.rs
@@ -1,0 +1,93 @@
+use serde_json::Value;
+use tiberius::{AuthMethod, Client, Config};
+use tokio::net::TcpStream;
+use tokio_util::compat::TokioAsyncWriteCompatExt;
+use tracing::info;
+use url::Url;
+
+use crate::error::AgentError;
+
+pub async fn execute(uri: &str, query: &str) -> Result<Value, AgentError> {
+    let (config, addr) = parse_uri(uri)?;
+
+    info!("connecting to mssql");
+
+    let tcp = TcpStream::connect(&addr)
+        .await
+        .map_err(|e| AgentError::Connection(format!("mssql TCP error: {e}")))?;
+    tcp.set_nodelay(true)
+        .map_err(|e| AgentError::Connection(format!("mssql TCP error: {e}")))?;
+
+    let mut client = Client::connect(config, tcp.compat_write())
+        .await
+        .map_err(|e| AgentError::Connection(format!("mssql connection error: {e}")))?;
+
+    // Use FOR JSON PATH for server-side JSON conversion
+    let json_query = format!(
+        "SELECT * FROM ({query}) AS q FOR JSON PATH, INCLUDE_NULL_VALUES"
+    );
+
+    let stream = client
+        .query(&json_query, &[])
+        .await
+        .map_err(|e| AgentError::Connection(format!("mssql query error: {e}")))?;
+
+    let rows = stream
+        .into_first_result()
+        .await
+        .map_err(|e| AgentError::Connection(format!("mssql fetch error: {e}")))?;
+
+    // FOR JSON PATH splits long JSON across multiple rows — concatenate them
+    let json_string: String = rows
+        .iter()
+        .filter_map(|row| row.try_get::<&str, _>(0).ok().flatten())
+        .collect();
+
+    if json_string.is_empty() {
+        return Ok(Value::Array(vec![]));
+    }
+
+    let result: Value = serde_json::from_str(&json_string)?;
+    Ok(result)
+}
+
+fn parse_uri(uri: &str) -> Result<(Config, String), AgentError> {
+    // Normalize mssql:// or sqlserver:// scheme to http:// for URL parsing
+    let normalized = if uri.starts_with("mssql://") {
+        uri.replacen("mssql://", "http://", 1)
+    } else if uri.starts_with("sqlserver://") {
+        uri.replacen("sqlserver://", "http://", 1)
+    } else {
+        uri.to_string()
+    };
+
+    let parsed = Url::parse(&normalized)
+        .map_err(|e| AgentError::Connection(format!("invalid mssql URI: {e}")))?;
+
+    let host = parsed.host_str().unwrap_or("localhost");
+    let port = parsed.port().unwrap_or(1433);
+
+    let mut config = Config::new();
+    config.host(host);
+    config.port(port);
+    config.trust_cert();
+
+    if let Some(db) = parsed
+        .path()
+        .strip_prefix('/')
+        .filter(|s| !s.is_empty())
+    {
+        config.database(db);
+    }
+
+    let username = if parsed.username().is_empty() {
+        "sa"
+    } else {
+        parsed.username()
+    };
+    let password = parsed.password().unwrap_or("");
+    config.authentication(AuthMethod::sql_server(username, password));
+
+    let addr = format!("{host}:{port}");
+    Ok((config, addr))
+}

--- a/src/query/mysql.rs
+++ b/src/query/mysql.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use serde_json::Value;
+use sqlx::mysql::{MySqlPool, MySqlRow};
+use sqlx::{Column, Row, TypeInfo};
+use tracing::info;
+
+use crate::error::AgentError;
+
+static POOLS: LazyLock<Mutex<HashMap<String, MySqlPool>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub async fn execute(uri: &str, query: &str) -> Result<Value, AgentError> {
+    let pool = {
+        let pools = POOLS.lock().unwrap();
+        pools.get(uri).cloned()
+    };
+
+    let pool = match pool {
+        Some(pool) => pool,
+        None => {
+            info!("creating new mysql connection pool");
+            let pool = MySqlPool::connect(uri).await?;
+            POOLS.lock().unwrap().insert(uri.to_string(), pool.clone());
+            pool
+        }
+    };
+
+    let rows: Vec<MySqlRow> = sqlx::query(query).fetch_all(&pool).await?;
+
+    let result: Vec<Value> = rows
+        .iter()
+        .map(|row| {
+            let mut obj = serde_json::Map::new();
+            for (i, col) in row.columns().iter().enumerate() {
+                let val = row_value_to_json(row, i, col.type_info().name());
+                obj.insert(col.name().to_string(), val);
+            }
+            Value::Object(obj)
+        })
+        .collect();
+
+    Ok(Value::Array(result))
+}
+
+fn row_value_to_json(row: &MySqlRow, index: usize, type_name: &str) -> Value {
+    if type_name == "BOOLEAN" {
+        return row
+            .try_get::<Option<bool>, _>(index)
+            .ok()
+            .flatten()
+            .map_or(Value::Null, Value::from);
+    }
+    if type_name.contains("INT") {
+        if type_name.contains("UNSIGNED") {
+            return row
+                .try_get::<Option<u64>, _>(index)
+                .ok()
+                .flatten()
+                .map_or(Value::Null, Value::from);
+        }
+        return row
+            .try_get::<Option<i64>, _>(index)
+            .ok()
+            .flatten()
+            .map_or(Value::Null, Value::from);
+    }
+    if type_name == "FLOAT" || type_name == "DOUBLE" {
+        return row
+            .try_get::<Option<f64>, _>(index)
+            .ok()
+            .flatten()
+            .map_or(Value::Null, Value::from);
+    }
+    if type_name == "JSON" {
+        return row
+            .try_get::<Option<String>, _>(index)
+            .ok()
+            .flatten()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or(Value::Null);
+    }
+    // DECIMAL, VARCHAR, TEXT, DATE, DATETIME, TIMESTAMP, etc.
+    row.try_get::<Option<String>, _>(index)
+        .ok()
+        .flatten()
+        .map_or(Value::Null, Value::from)
+}

--- a/src/query/postgres.rs
+++ b/src/query/postgres.rs
@@ -1,7 +1,31 @@
-use serde_json::Value;
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
 
-pub async fn execute(uri: &str, query: &str) -> Result<Value, Box<dyn std::error::Error>> {
-    let pool = sqlx::postgres::PgPool::connect(uri).await?;
+use serde_json::Value;
+use sqlx::postgres::PgPool;
+use tracing::info;
+
+use crate::error::AgentError;
+
+static POOLS: LazyLock<Mutex<HashMap<String, PgPool>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+pub async fn execute(uri: &str, query: &str) -> Result<Value, AgentError> {
+    let pool = {
+        let pools = POOLS.lock().unwrap();
+        pools.get(uri).cloned()
+    };
+
+    let pool = match pool {
+        Some(pool) => pool,
+        None => {
+            info!("creating new postgres connection pool");
+            let pool = PgPool::connect(uri).await?;
+            POOLS.lock().unwrap().insert(uri.to_string(), pool.clone());
+            pool
+        }
+    };
+
     let json_query = format!("SELECT JSON_AGG(t) FROM ({}) t", query);
     let result: Option<Value> = sqlx::query_scalar(&json_query).fetch_one(&pool).await?;
     Ok(result.unwrap_or(Value::Array(vec![])))


### PR DESCRIPTION
## Summary
- Refactor: split engine/connection/error into dedicated modules; query layer reorganized per-DB (mongo/mysql/mssql/postgres) with new `clickhouse` module
- Add ClickHouse query support
- Bump version 0.2.1 → 0.3.0