### PR TITLE
fix(dist): drop Windows release target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "kaiwadb-tunnel"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "clap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaiwadb-tunnel"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2024"
 repository = "https://github.com/kaiwadb/tunnel"
 license-file = "LICENSE"
@@ -49,13 +49,12 @@ cargo-dist-version = "0.21.1"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell"]
+installers = ["shell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
     "aarch64-apple-darwin",
     "x86_64-apple-darwin",
     "x86_64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc",
 ]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
@@ -68,7 +67,6 @@ allow-dirty = ["ci"]
 aarch64-apple-darwin = "macos-latest"
 x86_64-apple-darwin = "macos-latest"
 x86_64-unknown-linux-gnu = "ubuntu-latest"
-x86_64-pc-windows-msvc = "windows-latest"
 
 [package.metadata.dist]
 dist = true


### PR DESCRIPTION
## Summary
v0.7.1 release failed on Windows MSVC: \`resolv-conf\`'s \`#[link(name = \"c\")]\` is unconditional and MSVC has no \`c.lib\`. Linux + macOS targets pass cleanly.

Windows binaries were not in actual use, so dropping the target is the simpler fix than vendoring/patching resolv-conf. Bumps to 0.7.2.

## Test plan
- [x] Linux Docker CI green
- [x] cargo-dist plan still works
- [x] After merge + retag v0.7.2, Release workflow completes for the three remaining targets