### PR TITLE
feat: chunked streaming wire protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "kaiwadb-tunnel"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "clap",
  "futures-util",
@@ -2013,6 +2013,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -2031,12 +2032,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -3346,6 +3349,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kaiwadb-tunnel"
-version = "0.7.2"
+version = "0.8.0"
 edition = "2024"
 repository = "https://github.com/kaiwadb/tunnel"
 license-file = "LICENSE"
@@ -20,7 +20,7 @@ sqlx = { version = "0.8.6", features = [
     "chrono",
     "uuid",
 ] }
-reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "native-tls", "stream"] }
 tiberius = { version = "0.12", default-features = false, features = ["tds73", "native-tls"] }
 thiserror = "2"
 tokio = { version = "1.46.1", features = ["full"] }

--- a/src/communication.rs
+++ b/src/communication.rs
@@ -1,37 +1,42 @@
+//! Wire shapes between the tunnel and the kaiwadb server.
+//!
+//! Server → tunnel (text JSON):
+//!   `{"type":"command","id":<i64>,"request":{...ServerCommand...}}`
+//!
+//! Tunnel → server:
+//!   Text:   `{"type":"begin","id":<i64>}`
+//!   Binary: `[8-byte BE i64 cmd_id][payload bytes]`
+//!   Text:   `{"type":"end","id":<i64>,"error":null|"..."}`
+//!
+//! `begin` opens a response stream; binary frames carry chunks tagged with
+//! the cmd_id so multiple in-flight commands can interleave; `end` closes
+//! it. If `error` is non-null the response is considered failed regardless
+//! of any chunks already streamed.
+
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use tokio_tungstenite::tungstenite::Bytes;
 
 use crate::discovery::{Candidate, InterfaceInfo, SkippedSubnet};
 use crate::query::Query;
 
-/// Server -> tunnel frame. The id is the originating
-/// `tunnel_commands.id` row in the server's database, used to correlate
-/// responses without any in-process routing table.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerMessage {
     Command { id: i64, request: ServerCommand },
 }
 
-/// Tunnel -> server frame. The id always echoes back the originating
-/// command's id.
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub enum TunnelMessage {
-    Result { id: i64, payload: TunnelResult },
-    Error { id: i64, error: String },
+pub enum TunnelControl {
+    Begin { id: i64 },
+    End { id: i64, error: Option<String> },
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum ServerCommand {
     Query(Query),
     Scan(ScanRequest),
-}
-
-#[derive(Debug, Serialize)]
-pub enum TunnelResult {
-    QueryResult(Value),
-    ScanResult(ScanReport),
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -57,4 +62,15 @@ pub struct ScanReport {
     pub interfaces: Vec<InterfaceInfo>,
     pub duration_ms: u64,
     pub timed_out: bool,
+}
+
+pub const BIN_HDR: usize = 8;
+
+/// Wrap `payload` with an 8-byte cmd_id header. Returns a fresh allocation
+/// suitable for `Message::Binary`.
+pub fn frame_chunk(id: i64, payload: &[u8]) -> Bytes {
+    let mut buf = Vec::with_capacity(BIN_HDR + payload.len());
+    buf.extend_from_slice(&id.to_be_bytes());
+    buf.extend_from_slice(payload);
+    Bytes::from(buf)
 }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,15 +1,17 @@
 //! Tunnel WebSocket client.
 //!
-//! - Pings the server every [`HEARTBEAT_PERIOD`] so middle-boxes (ingress,
+//! - Pings the server every [`HEARTBEAT_PERIOD`] so middleboxes (ingress,
 //!   load balancers) keep the TCP idle timer reset.
-//! - Each command from the server is processed in its own task; results
-//!   funnel back through an mpsc channel to a single writer task. This means
-//!   a slow query doesn't block other queries on the same tunnel.
+//! - Each command from the server is processed in its own task and streams
+//!   its response back as `begin` + binary chunks (each tagged with the
+//!   8-byte cmd_id header) + `end`. Multiple in-flight commands can
+//!   interleave their chunks safely.
+//! - A single writer task drains the shared mpsc into the WebSocket sink
+//!   so concurrent handlers don't race on writes.
 //! - Reconnect uses exponential backoff capped at [`MAX_RECONNECT_DELAY`].
-//!   A 4001 close (server-side eviction by a newer connection) bypasses the
-//!   normal backoff and waits [`EVICTION_BACKOFF`] before trying again, to
-//!   avoid hammering when an operator has accidentally started two tunnels
-//!   with the same id.
+//!   A 4001 close (server-side lease loss, e.g. another tunnel took over)
+//!   bypasses the normal backoff and waits [`EVICTION_BACKOFF`] before
+//!   trying again.
 
 use futures_util::{SinkExt, StreamExt, stream::SplitSink};
 use std::time::Duration;
@@ -20,18 +22,20 @@ use tokio_tungstenite::{
     MaybeTlsStream, WebSocketStream, connect_async,
     tungstenite::{Message, client::IntoClientRequest, http::Request, protocol::CloseFrame},
 };
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
-use crate::communication::{ServerCommand, ServerMessage, TunnelMessage, TunnelResult};
+use crate::communication::{ServerCommand, ServerMessage, TunnelControl};
 use crate::discovery;
 use crate::error::TunnelError;
+use crate::query::stream_serializable;
 
 const HEARTBEAT_PERIOD: Duration = Duration::from_secs(15);
 const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
 const MAX_RECONNECT_DELAY: Duration = Duration::from_secs(30);
 const EVICTION_BACKOFF: Duration = Duration::from_secs(30);
 
-/// Server-defined close code: another tunnel connection took ownership.
+/// Server-defined close code: lease lost (another tunnel took over, or our
+/// presence row was swept after a network blip).
 const CLOSE_CODE_EVICTED: u16 = 4001;
 
 type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, Message>;
@@ -82,8 +86,9 @@ async fn connect_and_handle(
     info!("connected");
 
     let (write, mut read) = ws_stream.split();
-    // Buffer is small; backpressure on a slow socket is fine and slows down
-    // command processing rather than blowing up memory.
+    // mpsc capacity controls per-tunnel buffering. Small enough that a
+    // slow socket applies backpressure to the producing tasks (and
+    // transitively to the upstream DB read) rather than blowing memory.
     let (out_tx, out_rx) = mpsc::channel::<Message>(32);
 
     let writer_task = tokio::spawn(writer_loop(write, out_rx));
@@ -155,53 +160,42 @@ async fn writer_loop(mut write: WsSink, mut rx: mpsc::Receiver<Message>) {
 
 fn spawn_handler(msg: ServerMessage, out_tx: mpsc::Sender<Message>, no_scan: bool) {
     tokio::spawn(async move {
-        let response = handle_server_message(msg, no_scan).await;
-        let frame = match serde_json::to_string(&response) {
-            Ok(s) => Message::Text(s.as_str().into()),
-            Err(e) => {
-                error!(error = %e, "failed to serialize tunnel response");
-                return;
+        let ServerMessage::Command { id, request } = msg;
+        // begin
+        send_control(&out_tx, &TunnelControl::Begin { id }).await;
+
+        let result = match request {
+            ServerCommand::Query(query) => query.execute_streaming(id, &out_tx).await,
+            ServerCommand::Scan(req) => {
+                if no_scan {
+                    info!(cmd_id = id, "rejecting scan: disabled by operator");
+                    Err(crate::error::TunnelError::Connection(
+                        "scan disabled by operator".into(),
+                    ))
+                } else {
+                    let report = discovery::scan(req).await;
+                    stream_serializable(&report, id, &out_tx).await
+                }
             }
         };
-        if out_tx.send(frame).await.is_err() {
-            warn!("dropping tunnel response: writer channel closed");
-        }
+
+        let end = match result {
+            Ok(()) => TunnelControl::End { id, error: None },
+            Err(e) => TunnelControl::End {
+                id,
+                error: Some(e.to_string()),
+            },
+        };
+        send_control(&out_tx, &end).await;
     });
 }
 
-async fn handle_server_message(msg: ServerMessage, no_scan: bool) -> TunnelMessage {
-    let ServerMessage::Command { id, request } = msg;
-    match request {
-        ServerCommand::Query(query) => match query.execute().await {
-            Ok(data) => {
-                debug!(cmd_id = id, "query completed");
-                TunnelMessage::Result {
-                    id,
-                    payload: TunnelResult::QueryResult(data),
-                }
-            }
-            Err(e) => {
-                warn!(cmd_id = id, error = %e, "query failed");
-                TunnelMessage::Error {
-                    id,
-                    error: e.to_string(),
-                }
-            }
-        },
-        ServerCommand::Scan(req) => {
-            if no_scan {
-                info!(cmd_id = id, "rejecting scan: disabled by operator");
-                return TunnelMessage::Error {
-                    id,
-                    error: "scan disabled by operator".into(),
-                };
-            }
-            let report = discovery::scan(req).await;
-            debug!(cmd_id = id, candidates = report.candidates.len(), "scan complete");
-            TunnelMessage::Result {
-                id,
-                payload: TunnelResult::ScanResult(report),
-            }
-        }
+async fn send_control(out_tx: &mpsc::Sender<Message>, ctrl: &TunnelControl) {
+    let Ok(frame) = serde_json::to_string(ctrl) else {
+        error!("failed to serialize control frame");
+        return;
+    };
+    if out_tx.send(Message::Text(frame.as_str().into())).await.is_err() {
+        warn!("dropping control frame: writer channel closed");
     }
 }

--- a/src/query/clickhouse.rs
+++ b/src/query/clickhouse.rs
@@ -1,10 +1,11 @@
 use std::sync::LazyLock;
 
 use reqwest::Client;
-use serde::Deserialize;
-use serde_json::Value;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
 use tracing::info;
 
+use crate::communication::frame_chunk;
 use crate::error::TunnelError;
 use crate::params::ConnectionParams;
 
@@ -14,7 +15,26 @@ static HTTP_CLIENT: LazyLock<Client> = LazyLock::new(|| {
         .expect("failed to build HTTP client")
 });
 
-pub async fn execute(conn: &ConnectionParams, query: &str) -> Result<Value, TunnelError> {
+/// Approximate target frame size for streamed binary chunks. Sized below
+/// typical WebSocket buffers — large enough to keep per-frame overhead
+/// negligible, small enough to keep memory bounded on slow consumers.
+const CHUNK_TARGET: usize = 64 * 1024;
+
+/// Execute a ClickHouse query and stream its rows as a JSON array of
+/// row objects, framed for the tunnel protocol.
+///
+/// We ask ClickHouse for `FORMAT JSONEachRow` (one row per line) so the
+/// HTTP response body is naturally streamable, then transform it on the
+/// fly into `[{...},{...},...]` shape that the rest of the system
+/// expects (matching the old buffered behaviour). Bytes flow:
+/// reqwest body → line-batch → `frame_chunk` → mpsc → WS sink.
+/// Backpressure propagates end-to-end via the mpsc.
+pub async fn execute_streaming(
+    conn: &ConnectionParams,
+    query: &str,
+    id: i64,
+    out: &mpsc::Sender<Message>,
+) -> Result<(), TunnelError> {
     let ConnectionParams::Clickhouse {
         host,
         port,
@@ -35,16 +55,14 @@ pub async fn execute(conn: &ConnectionParams, query: &str) -> Result<Value, Tunn
     info!(url = %url, "executing clickhouse query");
 
     let mut request = HTTP_CLIENT.post(&url);
-
     if let Some(db) = database {
         request = request.query(&[("database", db.as_str())]);
     }
-
     if let Some(user) = username {
         request = request.basic_auth(user, password.as_deref());
     }
 
-    let body = format!("{query} FORMAT JSON");
+    let body = format!("{query} FORMAT JSONEachRow");
     let response = request
         .body(body)
         .send()
@@ -59,15 +77,77 @@ pub async fn execute(conn: &ConnectionParams, query: &str) -> Result<Value, Tunn
         )));
     }
 
-    let result: ClickhouseResponse = response
-        .json()
-        .await
-        .map_err(|e| TunnelError::Connection(format!("clickhouse response parse error: {e}")))?;
+    // Stream the body, splitting on newlines and re-emitting as a JSON
+    // array. We hold incomplete trailing bytes between chunks; complete
+    // lines are batched into ~`CHUNK_TARGET` outgoing frames.
+    let mut stream = response.bytes_stream();
+    use futures_util::StreamExt;
 
-    Ok(Value::Array(result.data))
+    let mut leftover: Vec<u8> = Vec::new();
+    let mut out_buf: Vec<u8> = Vec::with_capacity(CHUNK_TARGET + 1024);
+    let mut emitted_open = false;
+    let mut emitted_any_line = false;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| {
+            TunnelError::Connection(format!("clickhouse stream read error: {e}"))
+        })?;
+        leftover.extend_from_slice(&chunk);
+
+        // Emit every complete line in `leftover`; retain the partial tail.
+        while let Some(nl) = leftover.iter().position(|&b| b == b'\n') {
+            let line: Vec<u8> = leftover.drain(..nl).collect();
+            leftover.remove(0); // consume the newline
+            if line.is_empty() {
+                continue;
+            }
+            if !emitted_open {
+                out_buf.push(b'[');
+                emitted_open = true;
+            } else if emitted_any_line {
+                out_buf.push(b',');
+            }
+            out_buf.extend_from_slice(&line);
+            emitted_any_line = true;
+            if out_buf.len() >= CHUNK_TARGET {
+                flush(&mut out_buf, id, out).await?;
+            }
+        }
+    }
+
+    // ClickHouse normally ends with a trailing newline (already consumed
+    // above) but be defensive about a payload that doesn't.
+    if !leftover.is_empty() {
+        let line = std::mem::take(&mut leftover);
+        if !emitted_open {
+            out_buf.push(b'[');
+            emitted_open = true;
+        } else if emitted_any_line {
+            out_buf.push(b',');
+        }
+        out_buf.extend_from_slice(&line);
+    }
+
+    if !emitted_open {
+        // Zero rows. Emit an empty array.
+        out_buf.push(b'[');
+    }
+    out_buf.push(b']');
+    flush(&mut out_buf, id, out).await?;
+    Ok(())
 }
 
-#[derive(Deserialize)]
-struct ClickhouseResponse {
-    data: Vec<Value>,
+async fn flush(
+    buf: &mut Vec<u8>,
+    id: i64,
+    out: &mpsc::Sender<Message>,
+) -> Result<(), TunnelError> {
+    if buf.is_empty() {
+        return Ok(());
+    }
+    let payload = std::mem::take(buf);
+    out.send(Message::Binary(frame_chunk(id, &payload)))
+        .await
+        .map_err(|_| TunnelError::Connection("writer channel closed".into()))?;
+    Ok(())
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -8,18 +8,26 @@ use mongodb::bson::Document;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, from_value};
 use std::time::Instant;
+use tokio::sync::mpsc;
+use tokio_tungstenite::tungstenite::Message;
 use tracing::{debug, error, info};
 
+use crate::communication::frame_chunk;
 use crate::engine::Engine;
 use crate::error::TunnelError;
 use crate::params::ConnectionParams;
 
+/// Target frame size for buffered engines that don't stream natively. The
+/// query result Value is serialized to JSON once then sliced into binary
+/// chunks of this size.
+const CHUNK_TARGET: usize = 64 * 1024;
+
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct Query {
     pub connection: ConnectionParams,
-    /// Engine version metadata. Kept on the wire for future version-conditional
-    /// logic; not used for connection (backend validates engine/connection
-    /// variants match before forwarding).
+    /// Engine version metadata. Kept on the wire for future
+    /// version-conditional logic; not used for connection (backend
+    /// validates engine/connection variants match before forwarding).
     pub engine: Engine,
     pub data: Value,
 }
@@ -31,59 +39,97 @@ struct MongoData {
 }
 
 impl Query {
-    pub async fn execute(self) -> Result<Value, TunnelError> {
+    /// Execute the query and stream its response into `out` as framed
+    /// binary chunks tagged with `id`. Caller is responsible for sending
+    /// the surrounding `begin`/`end` control frames.
+    pub async fn execute_streaming(
+        self,
+        id: i64,
+        out: &mpsc::Sender<Message>,
+    ) -> Result<(), TunnelError> {
         let start = Instant::now();
+        let Query {
+            connection,
+            engine: _,
+            data,
+        } = self;
 
-        let Query { connection, engine: _, data } = self;
-
-        let result = match &connection {
-            ConnectionParams::Mongo { .. } => {
-                let MongoData {
-                    collection,
-                    pipeline,
-                } = from_value(data)?;
-                info!(collection = %collection, "executing mongodb query");
-                debug!(pipeline = ?pipeline);
-                mongo::execute(&connection, collection, pipeline).await
+        let outcome = match &connection {
+            ConnectionParams::Clickhouse { .. } => {
+                let query: String = from_value(data)?;
+                info!("executing clickhouse query");
+                debug!(query = %query);
+                clickhouse::execute_streaming(&connection, &query, id, out).await
             }
             ConnectionParams::Postgres { .. } => {
                 let query: String = from_value(data)?;
                 info!("executing postgresql query");
                 debug!(query = %query);
-                postgres::execute(&connection, &query).await
+                let value = postgres::execute(&connection, &query).await?;
+                stream_value(&value, id, out).await
             }
             ConnectionParams::Mysql { .. } => {
                 let query: String = from_value(data)?;
                 info!("executing mysql query");
                 debug!(query = %query);
-                mysql::execute(&connection, &query).await
+                let value = mysql::execute(&connection, &query).await?;
+                stream_value(&value, id, out).await
             }
             ConnectionParams::Mssql { .. } => {
                 let query: String = from_value(data)?;
                 info!("executing mssql query");
                 debug!(query = %query);
-                mssql::execute(&connection, &query).await
+                let value = mssql::execute(&connection, &query).await?;
+                stream_value(&value, id, out).await
             }
-            ConnectionParams::Clickhouse { .. } => {
-                let query: String = from_value(data)?;
-                info!("executing clickhouse query");
-                debug!(query = %query);
-                clickhouse::execute(&connection, &query).await
+            ConnectionParams::Mongo { .. } => {
+                let MongoData { collection, pipeline } = from_value(data)?;
+                info!(collection = %collection, "executing mongodb query");
+                debug!(pipeline = ?pipeline);
+                let value = mongo::execute(&connection, collection, pipeline).await?;
+                stream_value(&value, id, out).await
             }
         };
 
         let duration = start.elapsed();
-
-        match &result {
-            Ok(value) => {
-                info!(duration_ms = duration.as_millis(), "query completed");
-                debug!(result = %serde_json::to_string_pretty(value).unwrap_or_default());
-            }
-            Err(e) => {
-                error!(duration_ms = duration.as_millis(), error = %e, "query failed");
-            }
+        match &outcome {
+            Ok(()) => info!(duration_ms = duration.as_millis(), "query completed"),
+            Err(e) => error!(duration_ms = duration.as_millis(), error = %e, "query failed"),
         }
-
-        result
+        outcome
     }
+}
+
+/// Serialize `value` to JSON and stream as binary chunks. Used by engines
+/// that don't (yet) stream natively; their full result must fit in memory
+/// on the tunnel side but the WebSocket frame size limit no longer
+/// constrains the payload.
+async fn stream_value(
+    value: &Value,
+    id: i64,
+    out: &mpsc::Sender<Message>,
+) -> Result<(), TunnelError> {
+    let bytes = serde_json::to_vec(value)?;
+    for chunk in bytes.chunks(CHUNK_TARGET) {
+        out.send(Message::Binary(frame_chunk(id, chunk)))
+            .await
+            .map_err(|_| TunnelError::Connection("writer channel closed".into()))?;
+    }
+    Ok(())
+}
+
+/// Serialize an arbitrary `Serialize` value and stream it. Used for scan
+/// reports which never get large.
+pub async fn stream_serializable<T: Serialize>(
+    value: &T,
+    id: i64,
+    out: &mpsc::Sender<Message>,
+) -> Result<(), TunnelError> {
+    let bytes = serde_json::to_vec(value)?;
+    for chunk in bytes.chunks(CHUNK_TARGET) {
+        out.send(Message::Binary(frame_chunk(id, chunk)))
+            .await
+            .map_err(|_| TunnelError::Connection("writer channel closed".into()))?;
+    }
+    Ok(())
 }


### PR DESCRIPTION
## Summary
- Replace single-shot `result`/`error` frames with `begin` + binary chunks + `end`; each binary frame carries an 8-byte BE cmd_id header so multiple in-flight commands can interleave safely.
- ClickHouse streams natively via `FORMAT JSONEachRow`, transformed on the fly into the existing JSON-array shape. Other engines buffer then chunk, removing the WebSocket frame size limit as a payload cap.
- Backpressure propagates end-to-end through the writer mpsc.
- Bumps version to 0.8.0.

## Test plan
- [ ] ClickHouse: large result set streams; rows match prior buffered output
- [ ] Postgres/MySQL/MSSQL/Mongo: payloads larger than prior WS frame cap now succeed
- [ ] Concurrent queries on one tunnel interleave chunks without corruption
- [ ] `begin`/`end` always emitted (including error path)
- [ ] Server-side decoder handles the new framing